### PR TITLE
feat: add multiplayer skeleton with layout and matchmaker

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-bullseye-slim
+WORKDIR /app
+ENV NEXT_PUBLIC_WS_URL=ws://localhost:8081
+ENV NEXT_PUBLIC_MATCHMAKER_URL=http://localhost:8080
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY next.config.mjs tsconfig.json ./
+COPY app ./app
+COPY src ./src
+RUN npm run build
+EXPOSE 3000
+CMD ["npm","start"]

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,0 +1,174 @@
+'use client';
+import { useEffect, useRef, useState } from "react";
+import * as PIXI from "pixi.js";
+import { Types, Owner } from "../src/protocol";
+
+const MATCHMAKER_URL = process.env.NEXT_PUBLIC_MATCHMAKER_URL || "http://localhost:8080";
+
+type PlanetView = { id: number; x: number; y: number; r: number; owner: number; ships: number; production: number };
+type FleetView = { id: number; x: number; y: number; owner: number; to_id: number; ships: number };
+
+export default function Page() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const appRef = useRef<PIXI.Application | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const playerIdRef = useRef<number>(Owner.NEUTRAL);
+
+  const [sendPct, setSendPct] = useState(0.5);
+  const selectionRef = useRef<Set<number>>(new Set());
+  const planetsRef = useRef<Map<number, PlanetView>>(new Map());
+  const fleetsRef = useRef<Map<number, FleetView>>(new Map());
+
+  useEffect(() => {
+    const el = containerRef.current!;
+    const app = new PIXI.Application();
+    appRef.current = app;
+    app.init({ width: 1200, height: 800, background: "#0b0e1a", antialias: true }).then(() => {
+      el.appendChild(app.canvas);
+      connect();
+      setupTicker();
+      setupInput(app);
+    });
+
+    function setupTicker() {
+      const gPlanets = new PIXI.Graphics();
+      const gFleets = new PIXI.Graphics();
+      app.stage.addChild(gPlanets);
+      app.stage.addChild(gFleets);
+
+      app.ticker.add(() => {
+        gFleets.clear();
+        fleetsRef.current.forEach(f => {
+          gFleets.fill({ color: ownerColor(f.owner) }).circle(f.x, f.y, 3);
+        });
+
+        gPlanets.clear();
+        planetsRef.current.forEach(p => {
+          const sel = selectionRef.current.has(p.id);
+          const color = ownerColor(p.owner);
+          gPlanets.fill({ color }).circle(p.x, p.y, p.r);
+          gPlanets.stroke({ width: sel ? 4 : 2, color: sel ? 0x7ef7c7 : 0x22273a }).circle(p.x, p.y, p.r + 2);
+          const label = new PIXI.Text({ text: String(p.ships), style: { fill: 0xe7e9ee, fontSize: Math.max(12, Math.floor(p.r)) }});
+          label.anchor.set(0.5); label.position.set(p.x, p.y);
+          gPlanets.addChild(label);
+        });
+      });
+    }
+
+    function ownerColor(o: number) {
+      if (o === Owner.PLAYER1) return 0x35e0ff;
+      if (o === Owner.PLAYER2) return 0xff6a3d;
+      if (o === Owner.PLAYER3) return 0x00ff00;
+      if (o === Owner.PLAYER4) return 0xffff00;
+      return 0x8b8fa5;
+    }
+
+    async function connect() {
+      const res = await fetch(`${MATCHMAKER_URL}/join`);
+      const { wsUrl, roomId } = await res.json();
+      const ws = new WebSocket(`${wsUrl}?room=${roomId}`);
+      ws.binaryType = "arraybuffer";
+      ws.addEventListener("message", (ev) => {
+        const env = Types.ServerEnvelope.toObject(Types.ServerEnvelope.decode(new Uint8Array(ev.data)), { longs: String });
+        if (env.welcome) {
+          playerIdRef.current = env.welcome.player_id;
+          planetsRef.current.clear();
+          for (const pg of env.welcome.layout.planets || []) {
+            planetsRef.current.set(pg.id, { id: pg.id, x: pg.x, y: pg.y, r: pg.r, production: pg.production, owner: Owner.NEUTRAL, ships: 0 });
+          }
+          applySnapshot(env.welcome.snapshot);
+        } else if (env.snapshot) {
+          applySnapshot(env.snapshot);
+        } else if (env.delta) {
+          applyDelta(env.delta);
+        }
+      });
+      wsRef.current = ws;
+    }
+
+    function setupInput(app: PIXI.Application) {
+      const hitPlanet = (x: number, y: number) => {
+        for (const p of planetsRef.current.values()) {
+          if (Math.hypot(x - p.x, y - p.y) <= p.r) return p;
+        }
+        return null;
+      };
+      app.stage.eventMode = "static";
+      app.stage.hitArea = app.screen;
+      let lastClick = 0;
+      app.stage.on("pointerdown", (e: PIXI.FederatedPointerEvent) => {
+        const x = e.global.x, y = e.global.y;
+        const p = hitPlanet(x, y);
+        if (e.button === 2) {
+          if (p && selectionRef.current.size > 0) {
+            const from_ids = Array.from(selectionRef.current);
+            sendIssueOrders(from_ids, p.id, sendPct);
+          }
+          return;
+        }
+        if (!p) {
+          if (!e.shiftKey) selectionRef.current.clear();
+          return;
+        }
+        const now = performance.now();
+        const isDouble = now - lastClick < 300;
+        lastClick = now;
+        if (isDouble && p.owner === playerIdRef.current) {
+          selectionRef.current.clear();
+          planetsRef.current.forEach(pp => { if (pp.owner === playerIdRef.current) selectionRef.current.add(pp.id); });
+        } else {
+          if (p.owner !== playerIdRef.current) return;
+          if (e.shiftKey) selectionRef.current.add(p.id);
+          else { selectionRef.current.clear(); selectionRef.current.add(p.id); }
+        }
+      });
+      (app.view as any)?.addEventListener?.("contextmenu", (ev: Event) => ev.preventDefault());
+    }
+
+    function sendIssueOrders(from_ids: number[], target_id: number, pct: number) {
+      const payload = { issue_orders: { client_time_ms: Date.now().toString(), from_ids, target_id, pct, input_seq: 0 } };
+      const bytes = Types.ClientEnvelope.encode(Types.ClientEnvelope.fromObject(payload)).finish();
+      wsRef.current?.send(bytes);
+    }
+
+    function applySnapshot(s: any) {
+      for (const pd of s.planets || []) {
+        const p = planetsRef.current.get(pd.id);
+        if (p) { p.owner = pd.owner; p.ships = pd.ships; }
+      }
+      fleetsRef.current.clear();
+      for (const f of s.fleets || []) {
+        fleetsRef.current.set(f.id, { id: f.id, x: f.x, y: f.y, owner: f.owner, to_id: f.to_id, ships: f.ships });
+      }
+    }
+
+    function applyDelta(d: any) {
+      for (const pd of d.planets || []) {
+        const p = planetsRef.current.get(pd.id);
+        if (p) { p.owner = pd.owner; p.ships = pd.ships; }
+      }
+      for (const fd of d.fleets || []) {
+        const f = fleetsRef.current.get(fd.id);
+        if (f) { f.x = fd.x; f.y = fd.y; }
+      }
+      for (const id of d.remove_fleets || []) fleetsRef.current.delete(id);
+      for (const nf of d.new_fleets || []) {
+        fleetsRef.current.set(nf.id, { id: nf.id, x: nf.x, y: nf.y, owner: nf.owner, to_id: nf.to_id, ships: nf.ships });
+      }
+    }
+
+    return () => {
+      appRef.current?.destroy(true);
+      wsRef.current?.close();
+    };
+  }, [sendPct]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2 style={{ color: 'white', fontFamily: 'ui-sans-serif' }}>Swarm — Demo</h2>
+      <div style={{ color: '#aaa', marginBottom: 8 }}>LMB select, Shift+LMB multi, Double LMB select all yours, RMB send. Send % {Math.round(sendPct*100)}%</div>
+      <input type="range" min={10} max={100} step={10} value={Math.round(sendPct*100)} onChange={e=>setSendPct(parseInt(e.target.value)/100)} />
+      <div ref={containerRef} style={{ marginTop:12, border:"1px solid #223", width:1200, height:800 }} />
+    </div>
+  );
+}

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: false,
+  experimental: { appDir: true }
+};
+export default nextConfig;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "swarm-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "pixi.js": "^8.3.3",
+    "protobufjs": "^7.2.6"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4"
+  }
+}

--- a/apps/frontend/src/protocol.ts
+++ b/apps/frontend/src/protocol.ts
@@ -1,0 +1,141 @@
+import * as pb from "protobufjs/light";
+
+const PROTO = `
+syntax = "proto3";
+package swarm.v1;
+
+enum Owner {
+  NEUTRAL = 0;
+  PLAYER1 = 1;
+  PLAYER2 = 2;
+  PLAYER3 = 3;
+  PLAYER4 = 4;
+}
+
+message IssueOrders {
+  uint64 client_time_ms = 1;
+  repeated uint32 from_ids = 2;
+  uint32 target_id = 3;
+  float pct = 4;
+  uint32 input_seq = 5;
+}
+
+message RequestSnapshot {}
+
+message Ping {
+  uint64 client_time_ms = 1;
+  uint32 seq = 2;
+}
+
+message Pong {
+  uint64 server_time_ms = 1;
+  uint32 seq = 2;
+}
+
+message PlanetGeom {
+  uint32 id = 1;
+  float x = 2;
+  float y = 3;
+  float r = 4;
+  float production = 5;
+}
+
+message Layout {
+  repeated PlanetGeom planets = 1;
+}
+
+message PlanetDelta {
+  uint32 id = 1;
+  Owner owner = 2;
+  uint32 ships = 3;
+}
+
+message NewFleet {
+  uint32 id = 1;
+  Owner owner = 2;
+  uint32 from_id = 3;
+  uint32 to_id = 4;
+  float x = 5;
+  float y = 6;
+  float vx = 7;
+  float vy = 8;
+  uint32 ships = 9;
+}
+
+message FleetDelta {
+  uint32 id = 1;
+  float x = 2;
+  float y = 3;
+}
+
+message Snapshot {
+  uint32 tick = 1;
+  repeated PlanetDelta planets = 2;
+  repeated NewFleet fleets = 3;
+}
+
+message Delta {
+  uint32 tick = 1;
+  repeated PlanetDelta planets = 2;
+  repeated FleetDelta fleets = 3;
+  repeated uint32 remove_fleets = 4;
+  repeated NewFleet new_fleets = 5;
+}
+
+message Welcome {
+  uint32 room_id = 1;
+  uint32 tick_rate = 2;
+  uint32 delta_hz = 3;
+  uint32 player_id = 4;
+  Layout layout = 5;
+  Snapshot snapshot = 6;
+}
+
+message RoomEnded {
+  string reason = 1;
+}
+
+message ClientEnvelope {
+  oneof payload {
+    IssueOrders issue_orders = 1;
+    RequestSnapshot request_snapshot = 2;
+    Ping ping = 3;
+  }
+}
+
+message ServerEnvelope {
+  oneof payload {
+    Welcome welcome = 1;
+    Snapshot snapshot = 2;
+    Delta delta = 3;
+    Pong pong = 4;
+    RoomEnded ended = 5;
+  }
+}
+`;
+
+const root = pb.parse(PROTO).root;
+
+export const Types = {
+  ClientEnvelope: root.lookupType("swarm.v1.ClientEnvelope"),
+  ServerEnvelope: root.lookupType("swarm.v1.ServerEnvelope"),
+};
+
+export function encodeServer(obj: any): Uint8Array {
+  const msg = Types.ServerEnvelope.fromObject(obj);
+  return Types.ServerEnvelope.encode(msg).finish();
+}
+
+export function decodeClient(buf: ArrayBuffer | Uint8Array): any {
+  const msg = Types.ClientEnvelope.decode(new Uint8Array(buf as any));
+  return Types.ClientEnvelope.toObject(msg, { longs: String });
+}
+
+export enum Owner {
+  NEUTRAL = 0,
+  PLAYER1 = 1,
+  PLAYER2 = 2,
+  PLAYER3 = 3,
+  PLAYER4 = 4,
+}
+

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] },
+    "types": ["dom", "dom.iterable", "webworker"]
+  }
+}

--- a/apps/game-worker/Dockerfile
+++ b/apps/game-worker/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-bullseye-slim
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY tsconfig.json ./tsconfig.json
+COPY src ./src
+RUN npm run build
+EXPOSE 8081
+CMD ["npm","start"]

--- a/apps/game-worker/package.json
+++ b/apps/game-worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "swarm-game-worker",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "protobufjs": "^7.2.6",
+    "uWebSockets.js": "uNetworking/uWebSockets.js#v20.47.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.4"
+  }
+}

--- a/apps/game-worker/src/index.ts
+++ b/apps/game-worker/src/index.ts
@@ -1,0 +1,95 @@
+import uWS from "uWebSockets.js";
+import { decodeClient, encodeServer } from "./protocol";
+import { Room } from "./room";
+
+const TICK_HZ = 30;
+const DELTA_HZ = 15;
+
+class RoomManager {
+  rooms = new Map<number, Room>();
+  cfg = {
+    width: 1600,
+    height: 900,
+    seed: 13371337,
+    planetCount: 24,
+    minR: 18,
+    maxR: 34,
+    fleetSpeed: 120,
+    tickRate: TICK_HZ,
+    deltaHz: DELTA_HZ,
+    numPlayers: 2,
+  };
+
+  get(roomId: number) {
+    let r = this.rooms.get(roomId);
+    if (!r) {
+      r = new Room(roomId, this.cfg);
+      this.rooms.set(roomId, r);
+    }
+    return r;
+  }
+
+  tick(dt: number, now: number) {
+    for (const r of this.rooms.values()) r.tick(dt, now);
+  }
+}
+
+const manager = new RoomManager();
+
+const app = uWS.App();
+
+app.ws("/*", {
+  maxBackpressure: 1024 * 1024,
+  idleTimeout: 30,
+  compression: uWS.SHARED_COMPRESSOR,
+
+  upgrade: (res, req, context) => {
+    const url = req.getUrl();
+    const query = req.getQuery();
+    const params = new URLSearchParams(query);
+    const roomId = Number(params.get("room")) || 1;
+    res.upgrade({ roomId }, req.getHeader("sec-websocket-key"), req.getHeader("sec-websocket-protocol"), req.getHeader("sec-websocket-extensions"), context);
+  },
+
+  open: (ws) => {
+    const data = ws.getUserData() as any;
+    const room = manager.get(data.roomId);
+    room.join(ws as any);
+  },
+
+  message: (ws, message, isBinary) => {
+    try {
+      const env = decodeClient(isBinary ? message : message as ArrayBuffer);
+      const data = ws.getUserData() as any;
+      const room = manager.get(data.roomId);
+      if (env.issue_orders) {
+        const { from_ids, target_id, pct } = env.issue_orders;
+        room.issueOrdersFrom(ws as any, from_ids || [], Number(target_id), Math.max(0, Math.min(1, Number(pct))));
+      } else if (env.request_snapshot) {
+        room.join(ws as any);
+      } else if (env.ping) {
+        const pong = { pong: { server_time_ms: Date.now(), seq: env.ping.seq || 0 } };
+        (ws as any).send(encodeServer(pong), true);
+      }
+    } catch (e) {
+      // ignore
+    }
+  },
+
+  close: (ws) => {
+    const data = ws.getUserData() as any;
+    const room = manager.rooms.get(data.roomId);
+    room?.leave(ws as any);
+  }
+});
+
+const PORT = Number(process.env.PORT || 8081);
+app.listen(PORT, (token) => {
+  if (token) console.log(`Game worker listening on ws://localhost:${PORT}`);
+});
+
+const dt = 1 / TICK_HZ;
+setInterval(() => {
+  const now = Date.now();
+  manager.tick(dt, now);
+}, Math.floor(1000 / TICK_HZ));

--- a/apps/game-worker/src/protocol.ts
+++ b/apps/game-worker/src/protocol.ts
@@ -1,0 +1,141 @@
+import * as pb from "protobufjs/light";
+
+const PROTO = `
+syntax = "proto3";
+package swarm.v1;
+
+enum Owner {
+  NEUTRAL = 0;
+  PLAYER1 = 1;
+  PLAYER2 = 2;
+  PLAYER3 = 3;
+  PLAYER4 = 4;
+}
+
+message IssueOrders {
+  uint64 client_time_ms = 1;
+  repeated uint32 from_ids = 2;
+  uint32 target_id = 3;
+  float pct = 4;
+  uint32 input_seq = 5;
+}
+
+message RequestSnapshot {}
+
+message Ping {
+  uint64 client_time_ms = 1;
+  uint32 seq = 2;
+}
+
+message Pong {
+  uint64 server_time_ms = 1;
+  uint32 seq = 2;
+}
+
+message PlanetGeom {
+  uint32 id = 1;
+  float x = 2;
+  float y = 3;
+  float r = 4;
+  float production = 5;
+}
+
+message Layout {
+  repeated PlanetGeom planets = 1;
+}
+
+message PlanetDelta {
+  uint32 id = 1;
+  Owner owner = 2;
+  uint32 ships = 3;
+}
+
+message NewFleet {
+  uint32 id = 1;
+  Owner owner = 2;
+  uint32 from_id = 3;
+  uint32 to_id = 4;
+  float x = 5;
+  float y = 6;
+  float vx = 7;
+  float vy = 8;
+  uint32 ships = 9;
+}
+
+message FleetDelta {
+  uint32 id = 1;
+  float x = 2;
+  float y = 3;
+}
+
+message Snapshot {
+  uint32 tick = 1;
+  repeated PlanetDelta planets = 2;
+  repeated NewFleet fleets = 3;
+}
+
+message Delta {
+  uint32 tick = 1;
+  repeated PlanetDelta planets = 2;
+  repeated FleetDelta fleets = 3;
+  repeated uint32 remove_fleets = 4;
+  repeated NewFleet new_fleets = 5;
+}
+
+message Welcome {
+  uint32 room_id = 1;
+  uint32 tick_rate = 2;
+  uint32 delta_hz = 3;
+  uint32 player_id = 4;
+  Layout layout = 5;
+  Snapshot snapshot = 6;
+}
+
+message RoomEnded {
+  string reason = 1;
+}
+
+message ClientEnvelope {
+  oneof payload {
+    IssueOrders issue_orders = 1;
+    RequestSnapshot request_snapshot = 2;
+    Ping ping = 3;
+  }
+}
+
+message ServerEnvelope {
+  oneof payload {
+    Welcome welcome = 1;
+    Snapshot snapshot = 2;
+    Delta delta = 3;
+    Pong pong = 4;
+    RoomEnded ended = 5;
+  }
+}
+`;
+
+const root = pb.parse(PROTO).root;
+
+export const Types = {
+  ClientEnvelope: root.lookupType("swarm.v1.ClientEnvelope"),
+  ServerEnvelope: root.lookupType("swarm.v1.ServerEnvelope"),
+};
+
+export function encodeServer(obj: any): Uint8Array {
+  const msg = Types.ServerEnvelope.fromObject(obj);
+  return Types.ServerEnvelope.encode(msg).finish();
+}
+
+export function decodeClient(buf: ArrayBuffer | Uint8Array): any {
+  const msg = Types.ClientEnvelope.decode(new Uint8Array(buf as any));
+  return Types.ClientEnvelope.toObject(msg, { longs: String });
+}
+
+export enum Owner {
+  NEUTRAL = 0,
+  PLAYER1 = 1,
+  PLAYER2 = 2,
+  PLAYER3 = 3,
+  PLAYER4 = 4,
+}
+

--- a/apps/game-worker/src/room.ts
+++ b/apps/game-worker/src/room.ts
@@ -1,0 +1,107 @@
+import { SimState, SimConfig } from "./sim";
+import { encodeServer, Owner } from "./protocol";
+
+type WS = import("uWebSockets.js").SSLWebSocket<unknown> | import("uWebSockets.js").WebSocket<unknown>;
+
+export class Room {
+  id: number;
+  sim: SimState;
+  clients: Set<WS> = new Set();
+  players: Map<WS, Owner> = new Map();
+  private lastDeltaSent = 0;
+  private changedPlanets = new Set<number>();
+  private movedFleets: Map<number, { x: number; y: number }> = new Map();
+  private newFleets: any[] = [];
+
+  constructor(id: number, cfg: SimConfig) {
+    this.id = id;
+    this.sim = new SimState(cfg);
+  }
+
+  join(ws: WS): Owner {
+    this.clients.add(ws);
+    const owner = this.assignOwner();
+    this.players.set(ws, owner);
+    const layout = { planets: this.sim.planets.map(p => ({ id: p.id, x: p.x, y: p.y, r: p.r, production: p.production })) };
+    const snapshot = {
+      tick: this.sim.tick,
+      planets: this.sim.planets.map(p => ({ id: p.id, owner: p.owner, ships: Math.round(p.ships) })),
+      fleets: Array.from(this.sim.fleets.values()).map(f => ({
+        id: f.id, owner: f.owner, from_id: f.fromId, to_id: f.toId,
+        x: f.x, y: f.y, vx: f.vx, vy: f.vy, ships: f.ships
+      }))
+    };
+    const welcome = {
+      welcome: {
+        room_id: this.id,
+        tick_rate: this.sim.cfg.tickRate,
+        delta_hz: this.sim.cfg.deltaHz,
+        player_id: owner,
+        layout,
+        snapshot
+      }
+    };
+    ws.send(encodeServer(welcome), true);
+    return owner;
+  }
+
+  leave(ws: WS) {
+    this.clients.delete(ws);
+    this.players.delete(ws);
+  }
+
+  private assignOwner(): Owner {
+    const used = new Set(this.players.values());
+    if (!used.has(Owner.PLAYER1)) return Owner.PLAYER1;
+    if (!used.has(Owner.PLAYER2)) return Owner.PLAYER2;
+    if (!used.has(Owner.PLAYER3)) return Owner.PLAYER3;
+    if (!used.has(Owner.PLAYER4)) return Owner.PLAYER4;
+    return Owner.NEUTRAL;
+  }
+
+  issueOrdersFrom(ws: WS, fromIds: number[], targetId: number, pct: number) {
+    const owner = this.players.get(ws);
+    if (!owner || owner === Owner.NEUTRAL) return;
+    const created = this.sim.issueOrders(owner, fromIds, targetId, pct);
+    for (const f of created) {
+      this.newFleets.push({
+        id: f.id, owner: f.owner, from_id: f.fromId, to_id: f.toId,
+        x: f.x, y: f.y, vx: f.vx, vy: f.vy, ships: f.ships
+      });
+    }
+    for (const id of fromIds) this.changedPlanets.add(id);
+    if (targetId != null) this.changedPlanets.add(targetId);
+  }
+
+  tick(dt: number, nowMs: number) {
+    const { removed } = this.sim.step(dt);
+    for (const p of this.sim.planets) {
+      if (this.sim.tick % 4 === 0) this.changedPlanets.add(p.id);
+    }
+    for (const f of this.sim.fleets.values()) this.movedFleets.set(f.id, { x: f.x, y: f.y });
+
+    const minInterval = 1000 / this.sim.cfg.deltaHz;
+    if (nowMs - this.lastDeltaSent >= minInterval) {
+      this.lastDeltaSent = nowMs;
+      const delta = {
+        tick: this.sim.tick,
+        planets: Array.from(this.changedPlanets).map(id => {
+          const p = this.sim.planets[id];
+          return { id, owner: p.owner, ships: Math.round(p.ships) };
+        }),
+        fleets: Array.from(this.movedFleets.entries()).map(([id, pos]) => ({ id, x: pos.x, y: pos.y })),
+        remove_fleets: removed,
+        new_fleets: this.newFleets
+      };
+      const bytes = encodeServer({ delta });
+      this.broadcast(bytes);
+      this.changedPlanets.clear();
+      this.movedFleets.clear();
+      this.newFleets = [];
+    }
+  }
+
+  private broadcast(bytes: Uint8Array) {
+    for (const ws of this.clients) ws.send(bytes, true);
+  }
+}

--- a/apps/game-worker/src/sim.ts
+++ b/apps/game-worker/src/sim.ts
@@ -1,0 +1,125 @@
+import { Owner } from "./protocol";
+import { dist, randSeeded } from "./util";
+
+export interface Planet {
+  id: number; x: number; y: number; r: number;
+  owner: Owner; ships: number; production: number;
+}
+export interface Fleet {
+  id: number; owner: Owner; ships: number;
+  x: number; y: number; vx: number; vy: number;
+  fromId: number; toId: number;
+}
+
+export interface SimConfig {
+  width: number; height: number;
+  seed: number;
+  planetCount: number;
+  minR: number; maxR: number;
+  fleetSpeed: number;
+  tickRate: number;
+  deltaHz: number;
+  numPlayers: number;
+}
+
+export class SimState {
+  cfg: SimConfig;
+  tick = 0;
+  planets: Planet[] = [];
+  fleets: Map<number, Fleet> = new Map();
+  nextFleetId = 1;
+
+  constructor(cfg: SimConfig) {
+    this.cfg = cfg;
+    this.initMap();
+  }
+
+  private initMap() {
+    const { width, height, seed, planetCount, minR, maxR, numPlayers } = this.cfg;
+    const rand = randSeeded(seed);
+    const padding = 64;
+
+    while (this.planets.length < planetCount) {
+      const r = minR + (maxR - minR) * rand();
+      const x = padding + r + (width - 2 * (padding + r)) * rand();
+      const y = padding + r + (height - 2 * (padding + r)) * rand();
+      const production = (r / maxR) * (0.7 + rand() * 0.6);
+      const candidate: Planet = {
+        id: this.planets.length, x, y, r,
+        owner: Owner.NEUTRAL,
+        ships: Math.round(r * (1.2 + rand())),
+        production,
+      };
+      if (this.planets.every(p => dist(p.x, p.y, x, y) > p.r + r + 16)) {
+        this.planets.push(candidate);
+      }
+      if (this.planets.length > 2000) break;
+    }
+
+    if (this.planets.length >= numPlayers) {
+      // pick farthest pair for first two players
+      let bestI = 0, bestJ = 1, bestD = -1;
+      for (let i = 0; i < this.planets.length; i++)
+        for (let j = i + 1; j < this.planets.length; j++) {
+          const d = dist(this.planets[i].x, this.planets[i].y, this.planets[j].x, this.planets[j].y);
+          if (d > bestD) { bestD = d; bestI = i; bestJ = j; }
+        }
+      this.planets[bestI].owner = Owner.PLAYER1;
+      this.planets[bestI].ships = Math.max(40, this.planets[bestI].r * 2.2);
+      this.planets[bestI].production *= 1.1;
+      if (numPlayers >= 2) {
+        this.planets[bestJ].owner = Owner.PLAYER2;
+        this.planets[bestJ].ships = Math.max(40, this.planets[bestJ].r * 2.2);
+        this.planets[bestJ].production *= 1.1;
+      }
+    }
+  }
+
+  issueOrders(owner: Owner, fromIds: number[], targetId: number, pct: number) {
+    if (pct <= 0) return [] as Fleet[];
+    const target = this.planets.find(p => p.id === targetId);
+    if (!target) return [] as Fleet[];
+
+    const created: Fleet[] = [];
+    for (const id of fromIds) {
+      const from = this.planets.find(p => p.id === id);
+      if (!from || from.owner !== owner) continue;
+      if (from.id === targetId) continue;
+      const send = Math.floor(from.ships * Math.min(1, pct));
+      if (send <= 0) continue;
+      from.ships -= send;
+      const ang = Math.atan2(target.y - from.y, target.x - from.x);
+      const speed = this.cfg.fleetSpeed;
+      const vx = Math.cos(ang) * speed, vy = Math.sin(ang) * speed;
+      const fx = from.x + Math.cos(ang) * (from.r + 6);
+      const fy = from.y + Math.sin(ang) * (from.r + 6);
+      const f: Fleet = { id: this.nextFleetId++, owner, ships: send, x: fx, y: fy, vx, vy, fromId: from.id, toId: target.id };
+      this.fleets.set(f.id, f);
+      created.push(f);
+    }
+    return created;
+  }
+
+  step(dt: number) {
+    for (const p of this.planets) if (p.owner !== Owner.NEUTRAL) p.ships += p.production * dt;
+
+    const removed: number[] = [];
+    for (const f of this.fleets.values()) {
+      f.x += f.vx * dt; f.y += f.vy * dt;
+      const tgt = this.planets[f.toId];
+      if (tgt && dist(f.x, f.y, tgt.x, tgt.y) <= tgt.r) {
+        if (f.owner === tgt.owner) {
+          tgt.ships += f.ships;
+        } else {
+          const remaining = tgt.ships - f.ships;
+          if (remaining < 0) { tgt.owner = f.owner; tgt.ships = Math.abs(remaining); }
+          else { tgt.ships = remaining; }
+        }
+        removed.push(f.id);
+      }
+    }
+    for (const id of removed) this.fleets.delete(id);
+    this.tick++;
+    return { removed };
+  }
+}

--- a/apps/game-worker/src/util.ts
+++ b/apps/game-worker/src/util.ts
@@ -1,0 +1,14 @@
+export const nowMs = () => Date.now();
+
+export function randSeeded(seed: number) {
+  let t = seed >>> 0;
+  return () => {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export const dist = (x1: number, y1: number, x2: number, y2: number) =>
+  Math.hypot(x2 - x1, y2 - y1);

--- a/apps/game-worker/tsconfig.json
+++ b/apps/game-worker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/apps/matchmaker/Dockerfile
+++ b/apps/matchmaker/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-bullseye-slim
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY tsconfig.json ./tsconfig.json
+COPY src ./src
+RUN npm run build
+EXPOSE 8080
+CMD ["npm","start"]

--- a/apps/matchmaker/package.json
+++ b/apps/matchmaker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "swarm-matchmaker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node dist/index.js",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "tsx": "^4.16.2",
+    "typescript": "^5.5.4"
+  }
+}

--- a/apps/matchmaker/src/index.ts
+++ b/apps/matchmaker/src/index.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import Redis from "ioredis";
+
+const PORT = Number(process.env.PORT || 8080);
+const WS_URL = process.env.WS_URL || "ws://localhost:8081";
+const redisUrl = process.env.REDIS_URL || "redis://redis:6379";
+const redis = new Redis(redisUrl);
+
+const app = express();
+
+app.get("/join", async (_req, res) => {
+  const n = await redis.incr("join_counter");
+  const roomId = Math.ceil(n / 2);
+  res.json({ roomId, wsUrl: WS_URL });
+});
+
+app.listen(PORT, () => {
+  console.log(`Matchmaker listening on http://localhost:${PORT}`);
+});

--- a/apps/matchmaker/tsconfig.json
+++ b/apps/matchmaker/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  matchmaker:
+    build: ./apps/matchmaker
+    container_name: swarm-matchmaker
+    environment:
+      - REDIS_URL=redis://redis:6379
+      - WS_URL=ws://game-worker:8081
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+
+  game-worker:
+    build: ./apps/game-worker
+    container_name: swarm-game-worker
+    environment:
+      - PORT=8081
+    ports:
+      - "8081:8081"
+
+  frontend:
+    build: ./apps/frontend
+    container_name: swarm-frontend
+    environment:
+      - NEXT_PUBLIC_MATCHMAKER_URL=http://localhost:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      - matchmaker
+      - game-worker


### PR DESCRIPTION
## Summary
- add protobuf layout message and player identifiers
- implement room manager and multi-room game worker
- add Redis-backed matchmaker and wire via docker-compose

## Testing
- `npm --prefix apps/matchmaker install` *(fails: 403 Forbidden)*
- `npm --prefix apps/game-worker install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a533b422f88326ab3b7af04d0b448f