### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/apps/game-worker/src/global.d.ts
+++ b/apps/game-worker/src/global.d.ts
@@ -1,0 +1,1 @@
+declare const process: any;

--- a/apps/game-worker/src/room.ts
+++ b/apps/game-worker/src/room.ts
@@ -1,7 +1,7 @@
 import { SimState, SimConfig } from "./sim";
 import { encodeServer, Owner } from "./protocol";
 
-type WS = import("uWebSockets.js").SSLWebSocket<unknown> | import("uWebSockets.js").WebSocket<unknown>;
+type WS = import("uWebSockets.js").WebSocket<unknown>;
 
 export class Room {
   id: number;
@@ -61,7 +61,7 @@ export class Room {
 
   issueOrdersFrom(ws: WS, fromIds: number[], targetId: number, pct: number) {
     const owner = this.players.get(ws);
-    if (!owner || owner === Owner.NEUTRAL) return;
+    if (owner == null || owner === Owner.NEUTRAL) return;
     const created = this.sim.issueOrders(owner, fromIds, targetId, pct);
     for (const f of created) {
       this.newFleets.push({

--- a/apps/matchmaker/src/global.d.ts
+++ b/apps/matchmaker/src/global.d.ts
@@ -1,0 +1,6 @@
+declare module "express" {
+  const e: any;
+  export default e;
+}
+
+declare const process: any;

--- a/apps/matchmaker/src/index.ts
+++ b/apps/matchmaker/src/index.ts
@@ -8,7 +8,7 @@ const redis = new Redis(redisUrl);
 
 const app = express();
 
-app.get("/join", async (_req, res) => {
+app.get("/join", async (_req: any, res: any) => {
   const n = await redis.incr("join_counter");
   const roomId = Math.ceil(n / 2);
   res.json({ roomId, wsUrl: WS_URL });


### PR DESCRIPTION
## Summary
- allow TypeScript compilation without external type packages by adding minimal ambient declarations for Node and Express
- simplify game worker WebSocket type and owner checks to satisfy strict typing

## Testing
- `npx tsc -p apps/matchmaker/tsconfig.json`
- `npx tsc -p apps/game-worker/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68a53a125b9c8326879ad5ee770eccb2