### PR TITLE
Add root layout for Next.js frontend

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Swarm — Demo'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
-  experimental: { appDir: true }
+  reactStrictMode: false
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add missing root layout component for Next.js app
- remove deprecated experimental appDir flag from next.config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to install required TypeScript dependencies: @types/react)


------
https://chatgpt.com/codex/tasks/task_e_68a53d8a8f1c832686ca8b7826930068