### PR TITLE
Fix game worker import paths for Node ESM

### DIFF
--- a/apps/game-worker/src/index.ts
+++ b/apps/game-worker/src/index.ts
@@ -1,6 +1,6 @@
 import uWS from "uWebSockets.js";
-import { decodeClient, encodeServer } from "./protocol";
-import { Room } from "./room";
+import { decodeClient, encodeServer } from "./protocol.js";
+import { Room } from "./room.js";
 
 const TICK_HZ = 30;
 const DELTA_HZ = 15;

--- a/apps/game-worker/src/protocol.ts
+++ b/apps/game-worker/src/protocol.ts
@@ -1,4 +1,4 @@
-import * as pb from "protobufjs/light";
+import pb from "protobufjs";
 
 const PROTO = `
 syntax = "proto3";

--- a/apps/game-worker/src/room.ts
+++ b/apps/game-worker/src/room.ts
@@ -1,5 +1,5 @@
-import { SimState, SimConfig } from "./sim";
-import { encodeServer, Owner } from "./protocol";
+import { SimState, SimConfig } from "./sim.js";
+import { encodeServer, Owner } from "./protocol.js";
 
 type WS = import("uWebSockets.js").WebSocket<unknown>;
 

--- a/apps/game-worker/src/sim.ts
+++ b/apps/game-worker/src/sim.ts
@@ -1,5 +1,5 @@
-import { Owner } from "./protocol";
-import { dist, randSeeded } from "./util";
+import { Owner } from "./protocol.js";
+import { dist, randSeeded } from "./util.js";
 
 export interface Planet {
   id: number; x: number; y: number; r: number;


### PR DESCRIPTION
## Summary
- fix local imports in game worker to include `.js` extensions
- use full `protobufjs` package to access parser

## Testing
- `npm run build`
- `node dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68a5af4528f48326aa0aad7146f1c986