### PR TITLE
feat: add dota style hud and protoss board components

### DIFF
--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -2,12 +2,14 @@
 import { useState } from 'react';
 import SinglePlayerGame from '../components/SinglePlayerGame';
 import MultiPlayerGame from '../components/MultiPlayerGame';
+import GalconBoard from '../components/GalconBoard';
 
 export default function Page() {
-  const [mode, setMode] = useState<'menu' | 'single' | 'multi'>('menu');
+  const [mode, setMode] = useState<'menu' | 'single' | 'multi' | 'board'>('menu');
 
   if (mode === 'single') return <SinglePlayerGame />;
   if (mode === 'multi') return <MultiPlayerGame />;
+  if (mode === 'board') return <GalconBoard />;
 
   return (
     <div style={{ padding: 16 }}>
@@ -15,6 +17,7 @@ export default function Page() {
       <div style={{ marginTop: 12, display: 'flex', gap: 12 }}>
         <button onClick={() => setMode('single')}>Single Player</button>
         <button onClick={() => setMode('multi')}>Multiplayer</button>
+        <button onClick={() => setMode('board')}>Board Demo</button>
       </div>
     </div>
   );

--- a/apps/frontend/components/GalconBoard.tsx
+++ b/apps/frontend/components/GalconBoard.tsx
@@ -1,0 +1,140 @@
+'use client';
+import React, { useMemo, useState } from 'react';
+import Planet from './galcon/Planet';
+import TriBadge from './galcon/TriBadge';
+import Link from './galcon/Link';
+import Fleet from './galcon/Fleet';
+import { gold, aqua, red } from './galcon/palette';
+import { NodeData, LinkData, FleetGroup } from './galcon/types';
+
+const VIEW_W = 1200;
+const VIEW_H = 700;
+
+function lineId(a: string, b: string) {
+  return [a, b].sort().join('__');
+}
+
+export default function GalconBoard() {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const nodes: NodeData[] = useMemo(
+    () => [
+      { id: 'C', x: 600, y: 340, r: 96, value: 35, variant: 'aqua' },
+      { id: 'L1', x: 240, y: 130, r: 66, value: 20, variant: 'aqua' },
+      { id: 'L2', x: 360, y: 230, r: 28, value: 7, variant: 'aqua' },
+      { id: 'L3', x: 300, y: 430, r: 44, value: 4, variant: 'aqua' },
+      { id: 'L4', x: 420, y: 430, r: 26, value: 2, variant: 'aqua' },
+      { id: 'L5', x: 200, y: 340, r: 24, value: 7, variant: 'aqua' },
+      { id: 'B1', x: 600, y: 535, r: 38, value: 10, variant: 'aqua' },
+      { id: 'R1', x: 880, y: 130, r: 26, value: 8, variant: 'aqua' },
+      { id: 'R2', x: 1020, y: 110, r: 68, value: 18, variant: 'red' },
+      { id: 'R3', x: 820, y: 430, r: 38, value: 10, variant: 'aqua' },
+      { id: 'R4', x: 930, y: 290, r: 22, value: 8, variant: 'tri' },
+      { id: 'R5', x: 930, y: 170, r: 22, value: 8, variant: 'aqua' },
+    ],
+    []
+  );
+
+  const map = useMemo(() => Object.fromEntries(nodes.map(n => [n.id, n])), [nodes]);
+
+  const links: LinkData[] = useMemo(
+    () => [
+      { id: lineId('C', 'L1'), from: 'C', to: 'L1' },
+      { id: lineId('C', 'L2'), from: 'C', to: 'L2' },
+      { id: lineId('C', 'L3'), from: 'C', to: 'L3' },
+      { id: lineId('C', 'B1'), from: 'C', to: 'B1' },
+      { id: lineId('C', 'R1'), from: 'C', to: 'R1' },
+      { id: lineId('C', 'R3'), from: 'C', to: 'R3' },
+      { id: lineId('R1', 'R2'), from: 'R1', to: 'R2' },
+      { id: lineId('R1', 'R4'), from: 'R1', to: 'R4' },
+      { id: lineId('R3', 'B1'), from: 'R3', to: 'B1' },
+      { id: lineId('L2', 'L1'), from: 'L2', to: 'L1' },
+      { id: lineId('L3', 'L4'), from: 'L3', to: 'L4' },
+      { id: lineId('L5', 'L3'), from: 'L5', to: 'L3' },
+    ],
+    []
+  );
+
+  const fleets: FleetGroup[] = useMemo(
+    () => [
+      { id: 'F1', x: 215, y: 610, dx: 1, dy: -0.38, count: 7 },
+      { id: 'F2', x: 900, y: 620, dx: -1, dy: -0.52, count: 6 },
+    ],
+    []
+  );
+
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-black">
+      <svg viewBox={`0 0 ${VIEW_W} ${VIEW_H}`} className="w-full max-w-[1200px] drop-shadow-2xl">
+        <defs>
+          <radialGradient id="bgRad" cx="50%" cy="48%" r="70%">
+            <stop offset="0%" stopColor="#0a1722" />
+            <stop offset="100%" stopColor="#050b10" />
+          </radialGradient>
+          <radialGradient id="goldRad" cx="50%" cy="40%" r="70%">
+            <stop offset="0%" stopColor={gold.light} />
+            <stop offset="60%" stopColor={gold.base} />
+            <stop offset="100%" stopColor={gold.dark} />
+          </radialGradient>
+          <linearGradient id="goldStroke" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor={gold.light} />
+            <stop offset="100%" stopColor={gold.dark} />
+          </linearGradient>
+          <radialGradient id="core-aqua" cx="50%" cy="45%" r="70%">
+            <stop offset="0%" stopColor={aqua.core} />
+            <stop offset="100%" stopColor={aqua.deep} />
+          </radialGradient>
+          <radialGradient id="core-red" cx="50%" cy="45%" r="70%">
+            <stop offset="0%" stopColor={red.core} />
+            <stop offset="100%" stopColor={red.deep} />
+          </radialGradient>
+          <radialGradient id="glow-aqua" cx="50%" cy="50%" r="55%">
+            <stop offset="0%" stopColor="#40c8ff" stopOpacity={0.5} />
+            <stop offset="100%" stopColor="#40c8ff" stopOpacity={0} />
+          </radialGradient>
+          <radialGradient id="glow-red" cx="50%" cy="50%" r="55%">
+            <stop offset="0%" stopColor="#ff6e6e" stopOpacity={0.5} />
+            <stop offset="100%" stopColor="#ff6e6e" stopOpacity={0} />
+          </radialGradient>
+          <radialGradient id="glass" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="#ffffff" stopOpacity={0.18} />
+            <stop offset="100%" stopColor="#ffffff" stopOpacity={0} />
+          </radialGradient>
+          <filter id="marble">
+            <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="noStitch" />
+            <feColorMatrix type="saturate" values="0" />
+            <feComponentTransfer>
+              <feFuncA type="table" tableValues="0 0 0.02 0.06" />
+            </feComponentTransfer>
+            <feBlend mode="overlay" in2="SourceGraphic" />
+          </filter>
+          <pattern id="stars" width="200" height="200" patternUnits="userSpaceOnUse">
+            <rect width="200" height="200" fill="transparent" />
+            {Array.from({ length: 50 }).map((_, i) => (
+              <circle key={i} cx={(i * 37) % 200} cy={(i * 83) % 200} r={i % 3 === 0 ? 1.2 : 0.8} fill="#9fd8ff" opacity={0.45} />
+            ))}
+          </pattern>
+        </defs>
+
+        <rect x={0} y={0} width={VIEW_W} height={VIEW_H} fill="url(#bgRad)" />
+        <rect x={0} y={0} width={VIEW_W} height={VIEW_H} fill="url(#stars)" opacity={0.25} />
+
+        {links.map(l => (
+          <Link key={l.id} a={map[l.from]} b={map[l.to]} />
+        ))}
+
+        <Fleet g={fleets[0]} />
+
+        {nodes.map(n =>
+          n.variant === 'tri' ? (
+            <TriBadge key={n.id} n={n} />
+          ) : (
+            <Planet key={n.id} n={n} selected={selected === n.id} onClick={setSelected} />
+          )
+        )}
+
+        <Fleet g={fleets[1]} />
+      </svg>
+    </div>
+  );
+}

--- a/apps/frontend/components/Hud.tsx
+++ b/apps/frontend/components/Hud.tsx
@@ -1,0 +1,47 @@
+'use client';
+import React from 'react';
+
+interface Totals {
+  human: number;
+  ai: number;
+  neutral: number;
+}
+
+interface HudProps {
+  totals: Totals;
+  sendPercent: number;
+  setSendPercent: (v: number) => void;
+}
+
+function Circle({ value, size = 'w-16 h-16', gradient = 'from-blue-900 to-cyan-700', border = 'border-yellow-600' }: { value: number; size?: string; gradient?: string; border?: string; }) {
+  return (
+    <div className={`${size} rounded-full border-4 ${border} bg-gradient-to-b ${gradient} flex items-center justify-center text-white font-bold select-none`}>
+      {value}
+    </div>
+  );
+}
+
+export default function Hud({ totals, sendPercent, setSendPercent }: HudProps) {
+  return (
+    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-4 pointer-events-auto">
+      <Circle value={Math.round(totals.human)} gradient="from-teal-900 to-teal-600" border="border-cyan-400" />
+      <div className="w-8 h-0.5 bg-yellow-600" />
+      <div className="relative">
+        <Circle value={Math.round(sendPercent * 100)} size="w-24 h-24" gradient="from-sky-900 to-sky-600" border="border-yellow-500" />
+        <input
+          type="range"
+          min={5}
+          max={100}
+          step={5}
+          value={Math.round(sendPercent * 100)}
+          onChange={e => setSendPercent(Math.max(0.05, parseInt(e.target.value) / 100))}
+          className="absolute -bottom-5 left-1/2 -translate-x-1/2 w-24"
+        />
+      </div>
+      <div className="w-8 h-0.5 bg-yellow-600" />
+      <Circle value={Math.round(totals.ai)} gradient="from-red-900 to-red-600" border="border-red-500" />
+      <div className="w-8 h-0.5 bg-yellow-600" />
+      <Circle value={Math.round(totals.neutral)} gradient="from-gray-700 to-gray-500" border="border-gray-400" />
+    </div>
+  );
+}

--- a/apps/frontend/components/SinglePlayerGame.tsx
+++ b/apps/frontend/components/SinglePlayerGame.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useRef, useState } from "react";
+import Hud from "./Hud";
 
 /**
  * Swarm.Company — Galcon-like Prototype (Obstacle Avoid + Cohesion + Chunked Swarms)
@@ -62,8 +63,8 @@ interface GameRefs {
 }
 
 const COLORS = {
-  bg: "#0b0e1a", grid: "#111523", neutral: "#8b8fa5",
-  human: "#35e0ff", ai: "#ff6a3d", text: "#e7e9ee", selection: "#7ef7c7",
+  bg: "#02111b", grid: "#0a1a2a", neutral: "#9aa5b3",
+  human: "#2ac7d9", ai: "#e23e57", text: "#f8fafc", selection: "#ffd700",
 };
 const OWNER_COLOR = (p: Player) => (p === "HUMAN" ? COLORS.human : p === "AI" ? COLORS.ai : COLORS.neutral);
 const FIXED_DT = 1 / 60; // seconds
@@ -106,6 +107,7 @@ export default function SinglePlayerGame() {
   const [status, setStatus] = useState<"playing" | "won" | "lost">("playing");
   const [level, setLevel] = useState<number>(1);
   const [testLog, setTestLog] = useState<string[]>([]);
+  const [totals, setTotals] = useState({ human: 0, ai: 0, neutral: 0 });
 
   // Game state
   const planetsRef = useRef<Planet[]>([]);
@@ -426,13 +428,8 @@ export default function SinglePlayerGame() {
       selectionRef.current.planets.forEach((pid) => { const p = planetsRef.current.find(q => q.id === pid); if (!p) return; ctx.beginPath(); ctx.arc(p.x, p.y, p.r + 3, 0, Math.PI * 2); ctx.stroke(); });
     }
 
-    // HUD totals + Send%
-    const totals = countTotals();
-    ctx.fillStyle = COLORS.text; ctx.font = `${14 * (window.devicePixelRatio || 1)}px ui-sans-serif,system-ui`;
-    ctx.textAlign = "left"; ctx.fillText(
-      `You: ${Math.round(totals.human)}   AI: ${Math.round(totals.ai)}   Neutral: ${Math.round(totals.neutral)}   Send%: ${Math.round(sendPercent * 100)}%`,
-      16 * (window.devicePixelRatio || 1), 24 * (window.devicePixelRatio || 1)
-    );
+    // Update totals for HUD
+    setTotals(countTotals());
   }
 
   function drawPlanet(ctx: CanvasRenderingContext2D, p: Planet, sel: boolean) {
@@ -516,25 +513,13 @@ export default function SinglePlayerGame() {
   // UI
   // ============================
   return (
-    <div className="w-full min-h-screen bg-[#0b0e1a] text-white flex flex-col items-center py-6">
+    <div className="w-full min-h-screen bg-[#02111b] text-white flex flex-col items-center py-6">
       <div className="w-full max-w-5xl flex items-center justify-between px-4 mb-3">
         <div className="flex items-center gap-3">
           <div className="text-xl font-bold tracking-wide">Swarm.Company — Prototype</div>
           <div className="text-sm opacity-70">Level {level}</div>
         </div>
         <div className="flex items-center gap-3 flex-wrap">
-          <label className="text-sm opacity-80">Send %</label>
-          <input
-            type="range"
-            min={5}
-            max={100}
-            step={5}
-            value={Math.round(sendPercent * 100)}
-            className="w-48"
-            onChange={(e) => setSendPercent(Math.max(0.05, parseInt(e.target.value) / 100))}
-            title="Send percentage (wheel adjusts ±5%; 1–9 keys; 0 = 100%)"
-          />
-          <div className="text-sm tabular-nums">{Math.round(sendPercent * 100)}%</div>
           <button className="px-3 py-1.5 rounded-xl bg-cyan-500/20 hover:bg-cyan-500/30 border border-cyan-400/40" onClick={() => restart(level)} title="Restart (R)">Restart</button>
           <button className="px-3 py-1.5 rounded-xl bg-orange-500/20 hover:bg-orange-500/30 border border-orange-400/40" onClick={() => setLevel((l) => l + 1)} title="Next level (harder)">Next Level</button>
           <button className="px-3 py-1.5 rounded-xl bg-emerald-500/20 hover:bg-emerald-500/30 border border-emerald-400/40" onClick={runTests} title="Run built-in tests">Run Tests</button>
@@ -543,6 +528,7 @@ export default function SinglePlayerGame() {
 
       <div className="relative">
         <canvas ref={canvasRef} className="rounded-2xl shadow-[0_0_0_1px_rgba(255,255,255,.06)]" />
+        <Hud totals={totals} sendPercent={sendPercent} setSendPercent={setSendPercent} />
         {status !== "playing" && (
           <div className="absolute inset-0 flex items-center justify-center">
             <div className="backdrop-blur-sm bg-black/40 px-6 py-4 rounded-2xl border border-white/10 text-center">

--- a/apps/frontend/components/galcon/Fleet.tsx
+++ b/apps/frontend/components/galcon/Fleet.tsx
@@ -1,0 +1,15 @@
+'use client';
+import React from 'react';
+import FleetDart from './FleetDart';
+import { FleetGroup } from './types';
+
+export default function Fleet({ g }: { g: FleetGroup }) {
+  const angle = (Math.atan2(g.dy, g.dx) * 180) / Math.PI;
+  return (
+    <g>
+      {Array.from({ length: g.count }).map((_, i) => (
+        <FleetDart key={i} x={g.x + i * 30} y={g.y + (i % 2 === 0 ? -10 : 12)} rot={angle} />
+      ))}
+    </g>
+  );
+}

--- a/apps/frontend/components/galcon/FleetDart.tsx
+++ b/apps/frontend/components/galcon/FleetDart.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React from 'react';
+import { gold } from './palette';
+
+export default function FleetDart({ x, y, rot, scale = 1 }: { x: number; y: number; rot: number; scale?: number }) {
+  const s = 14 * scale;
+  const hull = [
+    `M 0 ${-s}`,
+    `L ${s * 1.1} 0`,
+    `L 0 ${s}`,
+    `L ${-s * 0.5} ${s * 0.38}`,
+    `L ${-s * 1.6} 0`,
+    `L ${-s * 0.5} ${-s * 0.38}`,
+    'Z',
+  ].join(' ');
+
+  const inset = [
+    `M 0 ${-s * 0.6}`,
+    `L ${s * 0.55} 0`,
+    `L 0 ${s * 0.6}`,
+    `L ${-s * 0.55} 0`,
+    'Z',
+  ].join(' ');
+
+  const gemR = s * 0.22;
+  const nose = `M ${s * 0.9} 0 L ${s * 1.1} 0 L ${s * 0.88} ${-s * 0.22} L ${s * 0.88} ${s * 0.22} Z`;
+
+  return (
+    <g transform={`translate(${x},${y}) rotate(${rot})`}>
+      <path d={`M ${-s * 1.6} 0 L ${-s * 3.8} 0`} stroke="#bff6ff" strokeOpacity={0.18} strokeWidth={7} />
+      <path d={`M ${-s * 1.6} -1.5 L ${-s * 3.1} -1.5`} stroke="#9feeff" strokeOpacity={0.38} strokeWidth={3} />
+      <path d={`M ${-s * 1.6} 1.5 L ${-s * 3.1} 1.5`} stroke="#9feeff" strokeOpacity={0.32} strokeWidth={3} />
+      <path d={hull} fill="url(#goldRad)" stroke="url(#goldStroke)" strokeWidth={3.6} strokeLinejoin="round" />
+      <path d={inset} fill="url(#core-aqua)" />
+      <polygon points={`${-s * 0.25},${-s * 0.48} ${-s * 0.05},0 ${-s * 0.25},${s * 0.48}`} fill="url(#goldRad)" opacity={0.9} />
+      <circle cx={-s * 0.05} cy={0} r={gemR} fill="url(#core-aqua)" stroke="url(#goldStroke)" strokeWidth={2.2} />
+      <path d={nose} fill="url(#goldRad)" />
+    </g>
+  );
+}

--- a/apps/frontend/components/galcon/Link.tsx
+++ b/apps/frontend/components/galcon/Link.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+import { NodeData } from './types';
+
+export default function Link({ a, b }: { a: NodeData; b: NodeData }) {
+  return (
+    <g>
+      <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#8fe9ff" strokeOpacity={0.12} strokeWidth={8} />
+      <line x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke="#53d5f0" strokeOpacity={0.7} strokeWidth={2} />
+    </g>
+  );
+}

--- a/apps/frontend/components/galcon/Planet.tsx
+++ b/apps/frontend/components/galcon/Planet.tsx
@@ -1,0 +1,74 @@
+'use client';
+import React from 'react';
+import { NodeData } from './types';
+import { gold } from './palette';
+
+function polarPoint(x: number, y: number, angleDeg: number, dist: number) {
+  const a = (angleDeg * Math.PI) / 180;
+  return { x: x + Math.cos(a) * dist, y: y + Math.sin(a) * dist };
+}
+
+function Crown() {
+  return (
+    <g transform="translate(0,-1)">
+      <path
+        d="M -58 -110 C -35 -150, 35 -150, 58 -110 L 40 -100 C 22 -128, -22 -128, -40 -100 Z"
+        fill={`url(#goldRad)`}
+        stroke={gold.dark}
+        strokeWidth={2}
+      />
+      <ellipse cx={0} cy={-120} rx={14} ry={18} fill="url(#core-aqua)" stroke="url(#goldStroke)" strokeWidth={5} />
+    </g>
+  );
+}
+
+function CornerGem({ a, dist, size }: { a: number; dist: number; size: number }) {
+  const p = polarPoint(0, 0, a, dist);
+  const s = size;
+  return (
+    <g transform={`translate(${p.x},${p.y})`}>
+      <polygon
+        points={`0,${-s} ${s},0 0,${s} ${-s},0`}
+        fill={`url(#goldRad)`}
+        stroke={gold.dark}
+        strokeWidth={1}
+      />
+      <circle r={s * 0.45} fill="url(#core-aqua)" stroke="url(#goldStroke)" strokeWidth={2.6} />
+    </g>
+  );
+}
+
+export default function Planet({ n, selected, onClick }: { n: NodeData; selected?: boolean; onClick?: (id: string) => void }) {
+  const isRed = n.variant === 'red';
+  const coreGrad = isRed ? 'core-red' : 'core-aqua';
+  const glowId = isRed ? 'glow-red' : 'glow-aqua';
+  const ring = Math.max(6, n.r * 0.18);
+  const halo = n.r * 1.5;
+  const fontSize = Math.max(14, n.r * 0.55);
+
+  return (
+    <g transform={`translate(${n.x},${n.y})`} onClick={() => onClick?.(n.id)} style={{ cursor: 'pointer' }}>
+      <circle r={halo} fill={`url(#${glowId})`} opacity={0.9} />
+      <circle r={n.r + ring + 10} fill="none" stroke={`url(#goldStroke)`} strokeWidth={8} opacity={0.9} />
+      <circle r={n.r + ring} fill={`url(#goldRad)`} stroke={gold.dark} strokeWidth={2} />
+      <circle r={n.r + Math.max(3, ring * 0.35)} fill="none" stroke={gold.dark} strokeOpacity={0.45} strokeWidth={2} />
+      {[0, 90, 180, 270].map((a, i) => (
+        <CornerGem key={i} a={a} dist={n.r + ring + 14} size={Math.max(6, n.r * 0.18)} />
+      ))}
+      <circle r={n.r} fill={`url(#${coreGrad})`} filter="url(#marble)" />
+      <ellipse cx={-n.r * 0.25} cy={-n.r * 0.35} rx={n.r * 0.65} ry={n.r * 0.42} fill="url(#glass)" />
+      <text
+        y={fontSize * 0.35}
+        textAnchor="middle"
+        fontSize={fontSize}
+        fontWeight={800}
+        fill="#e7fbff"
+        style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell' }}
+      >
+        {n.value}
+      </text>
+      {selected && <circle r={n.r + ring + 16} fill="none" stroke="#8ee7ff" strokeWidth={4} strokeOpacity={0.95} />}
+      {n.id === 'C' && <Crown />}
+    </g>
+  );
+}

--- a/apps/frontend/components/galcon/TriBadge.tsx
+++ b/apps/frontend/components/galcon/TriBadge.tsx
@@ -1,0 +1,34 @@
+'use client';
+import React from 'react';
+import { NodeData } from './types';
+
+export default function TriBadge({ n }: { n: NodeData }) {
+  const r = n.r;
+  const fs = r * 0.85;
+  return (
+    <g transform={`translate(${n.x},${n.y})`}>
+      <polygon
+        points={`${-r},${r} 0,${-r} ${r},${r}`}
+        fill={`url(#core-aqua)`}
+        filter="url(#marble)"
+        stroke={`url(#goldStroke)`}
+        strokeWidth={10}
+        strokeLinejoin="round"
+        opacity={0.98}
+      />
+      <circle cx={-r * 0.85} cy={r * 0.85} r={r * 0.12} fill="url(#goldRad)" />
+      <circle cx={0} cy={-r * 0.98} r={r * 0.12} fill="url(#goldRad)" />
+      <circle cx={r * 0.85} cy={r * 0.85} r={r * 0.12} fill="url(#goldRad)" />
+      <text
+        y={fs * 0.35}
+        textAnchor="middle"
+        fontSize={fs}
+        fontWeight={800}
+        fill="#e7fbff"
+        style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell' }}
+      >
+        {n.value}
+      </text>
+    </g>
+  );
+}

--- a/apps/frontend/components/galcon/palette.ts
+++ b/apps/frontend/components/galcon/palette.ts
@@ -1,0 +1,3 @@
+export const gold = { base: '#b88930', light: '#f2c46f', dark: '#6b4a17' };
+export const aqua = { core: '#7fe7ff', deep: '#0b6373' };
+export const red = { core: '#ff9a7f', deep: '#8b1e1e' };

--- a/apps/frontend/components/galcon/types.ts
+++ b/apps/frontend/components/galcon/types.ts
@@ -1,0 +1,25 @@
+export type Variant = 'aqua' | 'red' | 'tri';
+
+export interface NodeData {
+  id: string;
+  x: number;
+  y: number;
+  r: number; // core radius
+  value: number;
+  variant: Variant;
+}
+
+export interface LinkData {
+  id: string;
+  from: string;
+  to: string;
+}
+
+export interface FleetGroup {
+  id: string;
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  count: number;
+}


### PR DESCRIPTION
## Summary
- add Dota-inspired HUD with circular panels for send percent and totals
- introduce reusable Protoss-style board components for planets, links, and fleets
- include a board demo in the main menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a649807c1c83268bb33621fa6951d1