### PR TITLE
Add development Docker Compose configuration

### DIFF
--- a/apps/frontend/Dockerfile.dev
+++ b/apps/frontend/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM node:20-bullseye-slim
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY next.config.mjs tsconfig.json ./
+COPY app ./app
+COPY src ./src
+COPY components ./components
+EXPOSE 3000
+CMD ["npm","run","dev"]

--- a/apps/game-worker/Dockerfile.dev
+++ b/apps/game-worker/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node:20-bullseye-slim
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY tsconfig.json ./tsconfig.json
+COPY src ./src
+EXPOSE 8081
+CMD ["npm","run","dev"]

--- a/apps/matchmaker/Dockerfile.dev
+++ b/apps/matchmaker/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node:20-bullseye-slim
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+COPY tsconfig.json ./tsconfig.json
+COPY src ./src
+EXPOSE 8080
+CMD ["npm","run","dev"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,56 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  matchmaker:
+    build:
+      context: ./apps/matchmaker
+      dockerfile: Dockerfile.dev
+    container_name: swarm-matchmaker-dev
+    environment:
+      - NODE_ENV=development
+      - REDIS_URL=redis://redis:6379
+      - WS_URL=ws://game-worker:8081
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./apps/matchmaker:/app
+      - /app/node_modules
+    depends_on:
+      - redis
+
+  game-worker:
+    build:
+      context: ./apps/game-worker
+      dockerfile: Dockerfile.dev
+    container_name: swarm-game-worker-dev
+    environment:
+      - NODE_ENV=development
+      - PORT=8081
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./apps/game-worker:/app
+      - /app/node_modules
+
+  frontend:
+    build:
+      context: ./apps/frontend
+      dockerfile: Dockerfile.dev
+    container_name: swarm-frontend-dev
+    environment:
+      - NODE_ENV=development
+      - NEXT_PUBLIC_MATCHMAKER_URL=http://localhost:8080
+      - NEXT_PUBLIC_WS_URL=ws://localhost:8081
+      - CHOKIDAR_USEPOLLING=true
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./apps/frontend:/app
+      - /app/node_modules
+    depends_on:
+      - matchmaker
+      - game-worker

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,11 @@
+# Swarm Company
+
 Sample readme
+
+## Development environment
+
+Use the development Docker Compose file to start all services with hot reloading:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```


### PR DESCRIPTION
## Summary
- add dev-focused Dockerfiles for matchmaker, game worker, and frontend
- introduce docker-compose.dev.yml with volume mounts and dev envs
- document how to launch dev stack

## Testing
- `docker compose -f docker-compose.dev.yml config` *(fails: command not found)*
- `npm test` *(frontend: initiated build but did not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68ab63f5fe1c8326baf7a9756d62880a