### PR TITLE
Use ship sprite for fleets instead of rectangles

### DIFF
--- a/apps/frontend/components/SinglePlayerGame.tsx
+++ b/apps/frontend/components/SinglePlayerGame.tsx
@@ -462,10 +462,10 @@ export default function SinglePlayerGame() {
       ctx.translate(f.x, f.y);
       ctx.rotate(ang + Math.PI / 2);
       ctx.scale(scale, scale);
-      ctx.drawImage(img, -img.width / 2, -img.height / 2);
-      ctx.globalCompositeOperation = "source-atop";
       ctx.fillStyle = color;
       ctx.fillRect(-img.width / 2, -img.height / 2, img.width, img.height);
+      ctx.globalCompositeOperation = "destination-in";
+      ctx.drawImage(img, -img.width / 2, -img.height / 2);
       ctx.globalCompositeOperation = "source-over";
       ctx.restore();
     } else {


### PR DESCRIPTION
## Summary
- render fleet ships with image sprite tinted by owner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac88fdbad083269385bda6e86f15d9